### PR TITLE
feat: expose None entity types to allow finding things like ball lightning orbs

### DIFF
--- a/State/RuleState.cs
+++ b/State/RuleState.cs
@@ -14,6 +14,7 @@ public class RuleState
 {
     private readonly Lazy<NearbyMonsterInfo> _nearbyMonsterInfo;
     private readonly Lazy<List<EntityInfo>> _miscellaneousObjects;
+    private readonly Lazy<List<EntityInfo>> _noneEntities;
     private readonly RuleInternalState _internalState;
     private readonly Lazy<List<EntityInfo>> _ingameiconObjects;
 
@@ -76,6 +77,7 @@ public class RuleState
             Player = new MonsterInfo(controller, player);
             _nearbyMonsterInfo = new Lazy<NearbyMonsterInfo>(() => new NearbyMonsterInfo(plugin), LazyThreadSafetyMode.None);
             _miscellaneousObjects = new Lazy<List<EntityInfo>>(() => controller.EntityListWrapper.ValidEntitiesByType[EntityType.MiscellaneousObjects].Select(x => new EntityInfo(controller, x)).ToList(), LazyThreadSafetyMode.None);
+            _noneEntities = new Lazy<List<EntityInfo>>(() => controller.EntityListWrapper.ValidEntitiesByType[EntityType.None].Select(x => new EntityInfo(controller, x)).ToList(), LazyThreadSafetyMode.None);
             _ingameiconObjects = new Lazy<List<EntityInfo>>(() => controller.EntityListWrapper.ValidEntitiesByType[EntityType.IngameIcon].Select(x => new EntityInfo(controller, x)).ToList(), LazyThreadSafetyMode.None);
             _allMonsters = new Lazy<List<MonsterInfo>>(() => controller.EntityListWrapper.ValidEntitiesByType[EntityType.Monster]
                 .Where(e => NearbyMonsterInfo.IsValidMonster(plugin, e, false))
@@ -157,6 +159,9 @@ public class RuleState
 
     [Api]
     public IEnumerable<EntityInfo> MiscellaneousObjects => _miscellaneousObjects.Value;
+
+    [Api]
+    public IEnumerable<EntityInfo> NoneEntities => _noneEntities.Value;
 
     [Api]
     public IEnumerable<EntityInfo> IngameIcons => _ingameiconObjects.Value;


### PR DESCRIPTION
Example usage:
`NoneEntities.Any(entity => entity.Metadata.Contains("BallLightningPlayer")`